### PR TITLE
Update VotingEscrow.sol: Some Optimizations and error fixing

### DIFF
--- a/xNFTESourceCode/0x0303A0e45aE3Ee7c0027BFF0eF38310DFf79EEf9/sources/VotingEscrowNFTE/VotingEscrow.sol
+++ b/xNFTESourceCode/0x0303A0e45aE3Ee7c0027BFF0eF38310DFf79EEf9/sources/VotingEscrowNFTE/VotingEscrow.sol
@@ -63,11 +63,6 @@ contract VotingEscrow is Ownable, ReentrancyGuard {
     int128 internal constant iMAXTIME = 1 * 365 * 86400;
     uint internal constant MULTIPLIER = 1 ether;
 
-    uint public immutable MINTIME;
-    address public immutable token;
-    uint public supply;
-    bool public unlocked;
-
     mapping(address => LockedBalance) public locked;
 
     uint public epoch;
@@ -75,6 +70,11 @@ contract VotingEscrow is Ownable, ReentrancyGuard {
     mapping(address => Point[1000000000]) public user_point_history; // user -> Point[user_epoch]
     mapping(address => uint) public user_point_epoch;
     mapping(uint => int128) public slope_changes; // time -> signed slope change
+
+    uint public immutable MINTIME;
+    address public immutable token;
+    uint public supply;
+    bool public unlocked;
 
     // Aragon's view methods for compatibility
     address public controller;
@@ -154,7 +154,7 @@ contract VotingEscrow is Ownable, ReentrancyGuard {
 
     /// @notice Record global and per-user data to checkpoint
     /// @param _addr User's wallet address. No user checkpoint if 0x0
-    /// @param old_locked Pevious locked amount / end lock time for the user
+    /// @param old_locked Previous locked amount / end lock time for the user
     /// @param new_locked New locked amount / end lock time for the user
     function _checkpoint(address _addr, LockedBalance memory old_locked, LockedBalance memory new_locked) internal {
         Point memory u_old;
@@ -177,7 +177,7 @@ contract VotingEscrow is Ownable, ReentrancyGuard {
 
             // Read values of scheduled changes in the slope
             // old_locked.end can be in the past and in the future
-            // new_locked.end can ONLY by in the FUTURE unless everything expired: than zeros
+            // new_locked.end can ONLY be in the FUTURE unless everything expired: than zeros
             old_dslope = slope_changes[old_locked.end];
             if (new_locked.end != 0) {
                 if (new_locked.end == old_locked.end) {
@@ -258,7 +258,7 @@ contract VotingEscrow is Ownable, ReentrancyGuard {
             }
         }
 
-        // Record the changed point into history
+        // Record the changed point in history
         point_history[_epoch] = last_point;
 
         if (_addr != address(0x0)) {


### PR DESCRIPTION
Here's the explanation of why I changed the order of those particular state variables:

Usually, EVM stores state variables or storage variables in slots, each slot upto 32 bytes of data and these slots are directly related to gas, i.e more the slots, more the gas gonna be used up!!

So if by anyway we reduced the number of slots, we might optimize the gas a little bit. Take a look at this:

![Screenshot (15)](https://github.com/NFTEarth/nfte-token/assets/88618913/1c930094-48b9-404a-97ee-937c621f1cf6)

Just for some information sake:

- Address takes up 20 bytes
- bool takes up 1 byte
- uint256 takes up 32 bytes and covers up the whole storage

```
// Before any changes:
// Let's suppose there's a contract ABC (here I be including the part of the original contract to make it meaningful)
contract ABC{
    // targeted state variables from the original contract
    // We be excluding mappings here, cuz mapping used to have their own technique of listing data in slots

    uint public supply; // 32 bytes - slot 0 (let's suppose evm storage started from here)
    bool public unlocked; // 1 byte - slot 1

    mapping(address => LockedBalance) public locked;

    uint public epoch; 32 bytes - slot 2
    mapping(uint => Point) public point_history; // epoch -> unsigned point
    mapping(address => Point[1000000000]) public user_point_history; // user -> Point[user_epoch]
    mapping(address => uint) public user_point_epoch;
    mapping(uint => int128) public slope_changes; // time -> signed slope change

    // Aragon's view methods for compatibility
    address public controller; 20 bytes - slot 3
    bool public transfersEnabled; 1 byte - slot 3,  slot 3 - 21 bytes till now
}
// contract ABC used up 4 slots (from 0 to 3) in order to include these state variables (excluding mappings)

// After changes:

contract DEF{
    mapping(address => LockedBalance) public locked;

    uint public epoch; // 32 bytes - slot 0
    mapping(uint => Point) public point_history; // epoch -> unsigned point
    mapping(address => Point[1000000000]) public user_point_history; // user -> Point[user_epoch]
    mapping(address => uint) public user_point_epoch;
    mapping(uint => int128) public slope_changes; // time -> signed slope change

    uint public supply; // 32 bytes - slot 1
    bool public unlocked; // 1 byte - slot 2

    // Aragon's view methods for compatibility
    address public controller; // 20 bytes - slot 2 , hmm slot 2 still have the space
    bool public transfersEnabled; // 1 byte - slot 2, slot 2 - 22 bytes 
}
// It used up 3 slots in total (from 0 to 2)
```

Saving 1 extra slot, Hope that makes you clear!!

and if anyone seek more information on this particular change, this link will be helpful -> https://coinsbench.com/solidity-layout-and-access-of-storage-variables-simply-explained-1ce964d7c738

Plus, there are some error fixes which are pretty clear in the `file changed`!!